### PR TITLE
main: updating the version properly pin patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ EXAMPLE
 ```hcl
 module "lb-masters" {
   source  = "dcos-terraform/lb-masters/azurerm"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "production"
 

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@
  *```hcl
  * module "lb-masters" {
  *   source  = "dcos-terraform/lb-masters/azurerm"
- *   version = "~> 0.1"
+ *   version = "~> 0.1.0"
  *
  *   cluster_name = "production"
  *


### PR DESCRIPTION
This updates the version behaivor to have ~> 0.1.0: any non-beta version >= 0.1.0 and < 0.2.0

https://www.terraform.io/docs/modules/usage.html#gt-1-2