### PR TITLE
Update to latest Azure Provider APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ module "lb-masters" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | cluster_name | Name of the DC/OS cluster | string | - | yes |
+| instance_nic_ids | List of instance nic ids created by this module | list | - | yes |
+| ip_configuration_names | List of ip configuration names associated with the instance nic ids | list | - | yes |
 | location | Azure Region | string | - | yes |
+| num | How many instances should be created | string | - | yes |
 | resource_group_name | Name of the azure resource group | string | - | yes |
 | tags | Add custom tags to all resources | map | `<map>` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,9 @@ module "masters" {
   location            = "${var.location}"
   resource_group_name = "${var.resource_group_name}"
 
+  instance_nic_ids       = ["${var.instance_nic_ids}"]
+  ip_configuration_names = ["${var.ip_configuration_names}"]
+
   providers = {
     azurerm = "azurerm"
   }
@@ -39,6 +42,8 @@ module "masters" {
   probe {
     port = 5050
   }
+
+  num = "${var.num}"
 
   tags = "${var.tags}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,16 @@ variable "cluster_name" {
   description = "Name of the DC/OS cluster"
 }
 
+variable "instance_nic_ids" {
+  description = "List of instance nic ids created by this module"
+  type        = "list"
+}
+
+variable "ip_configuration_names" {
+  description = "List of ip configuration names associated with the instance nic ids"
+  type        = "list"
+}
+
 variable "resource_group_name" {
   description = "Name of the azure resource group"
 }
@@ -14,4 +24,9 @@ variable "tags" {
   description = "Add custom tags to all resources"
   type        = "map"
   default     = {}
+}
+
+# Number of Instance
+variable "num" {
+  description = "How many instances should be created"
 }


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-49945

Azure has deprecated some of their api and requires universal installer updates in order for us to continue to use these changes. Whenever there is a new resource introduced into the templates, this is considered a breaking change to our definition and requires an update to a minor version of the universal installer.

There is a limitation/workaround here that was used within these 0.2 change that will be updated when terraform v0.12.0 is released.

The issue is located here: `https://github.com/hashicorp/terraform/issues/12570`